### PR TITLE
feat(cache): scope GET caching by public/private API

### DIFF
--- a/docs/middleware/cache.md
+++ b/docs/middleware/cache.md
@@ -71,6 +71,10 @@ The Cache middleware provides response caching for GET APIs with per-API TTL con
           "GET /users": {
             "enabled": true
             // Uses defaultTTL (300000ms)
+          },
+          "GET /profile": {
+            "enabled": true,
+            "scope": "tenant_user"        // Cache per tenant + logged-in user
           }
         }
       },
@@ -100,6 +104,27 @@ The Cache middleware provides response caching for GET APIs with per-API TTL con
 | `services.[name].apis` | object | `{}` | API-specific cache configuration |
 | `services.[name].apis[api].enabled` | boolean | `false` | Enable caching for this API |
 | `services.[name].apis[api].ttl` | number | `defaultTTL` | Cache TTL for this API |
+| `services.[name].apis[api].scope` | string | inferred | Cache scope: `"tenant"` or `"tenant_user"`. Defaults to `"tenant"` for public APIs and `"tenant_user"` for private APIs. |
+
+## Caching Scope (Public vs Private APIs)
+
+The cache key dimension depends on whether the API is **public** (no `access_token` required) or **private** (requires an `access_token`):
+
+- **Public API** → the response is the same for the whole tenant, so it is cached per **tenant** (`scope: "tenant"`). The cache key contains the tenant id only.
+- **Private API** → the response can differ per logged-in user, so it is cached per **tenant + user** (`scope: "tenant_user"`). The cache key also includes the user id, preventing one user from receiving another user's cached response.
+
+The gateway determines public vs private automatically from `req.soajs.controller.serviceParams.isAPIPublic` and resolves the default scope accordingly. You can override the scope per API with the `scope` field.
+
+| Scope | Cache key dimension | Default for |
+|-------|---------------------|-------------|
+| `tenant` | tenant id | Public APIs |
+| `tenant_user` | tenant id + user id | Private APIs |
+
+### Safety Behavior
+
+If an API resolves to `tenant_user` scope but **no logged-in user can be resolved** (no URAC user on the request), the response is **not cached**. This prevents a user-scoped entry from being stored without a user identity and served to the wrong user. A misconfiguration therefore causes a cache miss, never a data leak.
+
+An unrecognized `scope` value is ignored (with a warning) and falls back to the inferred default.
 
 ## API Pattern Matching
 
@@ -116,9 +141,16 @@ APIs are matched using `GET /path` format with support for path parameters:
 ## Cache Key Structure
 
 ```javascript
+// Public API (scope: "tenant")
 {
   "l1": "tenant_id",
   "l2": "serviceName:GET:/path:queryHash"
+}
+
+// Private API (scope: "tenant_user")
+{
+  "l1": "tenant_id",
+  "l2": "serviceName:GET:/path:queryHash:u:user_id"
 }
 ```
 
@@ -126,6 +158,7 @@ APIs are matched using `GET /path` format with support for path parameters:
 - **serviceName**: The target service name
 - **path**: The API path
 - **queryHash**: MD5 hash of sorted query parameters
+- **user_id**: The logged-in user id (only for `tenant_user` scope), isolating cache per user within the tenant
 
 ### Query Parameter Handling
 
@@ -199,7 +232,9 @@ Content-Type: application/json
 ## Usage Notes
 
 - Only GET requests are cached
-- Cache is tenant-isolated
+- Cache is tenant-isolated; private APIs are additionally user-isolated (`tenant_user` scope)
+- Public APIs default to `tenant` scope, private APIs default to `tenant_user` scope
+- Private (`tenant_user`) requests without a resolved user are not cached (safety)
 - Query parameters affect cache key
 - Only 2xx responses are cached
 - Headers like `X-Cache` are not stored in cache
@@ -226,12 +261,15 @@ Content-Type: application/json
 }
 ```
 
-### User-Specific Data
+### User-Specific Data (Private API)
 
 ```javascript
-// Cache key includes tenant ID, so each tenant has separate cache
+// Private API: cache key includes tenant ID AND user ID,
+// so each user within a tenant has a separate cache entry.
+// "tenant_user" is the default scope for private APIs, shown here explicitly.
 "GET /users/profile": {
   "enabled": true,
-  "ttl": 60000    // 1 minute
+  "ttl": 60000,        // 1 minute
+  "scope": "tenant_user"
 }
 ```

--- a/mw/cache/index.js
+++ b/mw/cache/index.js
@@ -106,11 +106,36 @@ module.exports = function (configuration) {
 			return next();
 		}
 
+		// Determine caching scope.
+		// Public APIs (no access_token required) return the same response for the whole
+		// tenant, so they are cached per tenant ("tenant"). Private APIs may return a
+		// different response per logged-in user, so they must be cached per tenant + user
+		// ("tenant_user") to avoid serving one user's response to another.
+		// Scope can be overridden per API in the custom registry via apiConfig.scope.
+		// Default: public -> "tenant", private -> "tenant_user".
+		const isAPIPublic = req.soajs.controller.serviceParams.isAPIPublic;
+		const userId = req.soajs.uracDriver && req.soajs.uracDriver.id;
+
+		let scope = apiConfig.scope;
+		if (scope !== 'tenant' && scope !== 'tenant_user') {
+			if (scope) {
+				configuration.log.warn('Cache: Unknown scope [' + scope + '] for API [' + method + ' ' + apiPath + ']. It can only be [tenant || tenant_user]. Falling back to default.');
+			}
+			scope = isAPIPublic ? 'tenant' : 'tenant_user';
+		}
+
+		// Safety: a user-scoped entry without a resolved user would leak across users.
+		// Skip caching rather than risk serving the wrong user's response.
+		if (scope === 'tenant_user' && !userId) {
+			return next();
+		}
+
 		const ttl = apiConfig.ttl || cacheConfig.defaultTTL || 300000;
 		const queryHash = hashQuery(req.query);
+		const userPart = (scope === 'tenant_user') ? `:u:${userId}` : '';
 		const key = {
 			'l1': req.soajs.tenant.id,
-			'l2': `${serviceName}:GET:${apiPath}:${queryHash}`
+			'l2': `${serviceName}:GET:${apiPath}:${queryHash}${userPart}`
 		};
 
 		const processCache = async () => {

--- a/mw/cache/model/memory.js
+++ b/mw/cache/model/memory.js
@@ -25,6 +25,10 @@ let model = {
 		cleanupInterval = setInterval(() => {
 			model.cleanupExpiredEntries();
 		}, CLEANUP_INTERVAL);
+		// Do not keep the event loop alive solely for the cleanup timer.
+		if (cleanupInterval.unref) {
+			cleanupInterval.unref();
+		}
 	},
 
 	'cleanupExpiredEntries': () => {

--- a/mw/idempotency/model/memory.js
+++ b/mw/idempotency/model/memory.js
@@ -25,6 +25,10 @@ let model = {
 		cleanupInterval = setInterval(() => {
 			model.cleanupExpiredEntries();
 		}, CLEANUP_INTERVAL);
+		// Do not keep the event loop alive solely for the cleanup timer.
+		if (cleanupInterval.unref) {
+			cleanupInterval.unref();
+		}
 	},
 
 	'cleanupExpiredEntries': () => {

--- a/mw/traffic/model/memory.js
+++ b/mw/traffic/model/memory.js
@@ -25,6 +25,10 @@ let model = {
         cleanupInterval = setInterval(() => {
             model.cleanupExpiredEntries();
         }, CLEANUP_INTERVAL);
+        // Do not keep the event loop alive solely for the cleanup timer.
+        if (cleanupInterval.unref) {
+            cleanupInterval.unref();
+        }
     },
 
     'cleanupExpiredEntries': () => {

--- a/test/unit/mw/cache/index.js
+++ b/test/unit/mw/cache/index.js
@@ -221,7 +221,7 @@ describe("Unit test for: mw - cache", () => {
 				query: {},
 				soajs: {
 					tenant: { id: 'tenant-cache-miss' },
-					controller: { serviceParams: { name: 'test', serviceInfo: ['', 'test', 'test'] } },
+					controller: { serviceParams: { name: 'test', serviceInfo: ['', 'test', 'test'], isAPIPublic: true } },
 					registry: {
 						custom: {
 							gateway: {
@@ -264,7 +264,7 @@ describe("Unit test for: mw - cache", () => {
 				query: {},
 				soajs: {
 					tenant: { id: 'tenant-param-cache' },
-					controller: { serviceParams: { name: 'test', serviceInfo: ['', 'test', 'users', '123'] } },
+					controller: { serviceParams: { name: 'test', serviceInfo: ['', 'test', 'users', '123'], isAPIPublic: true } },
 					registry: {
 						custom: {
 							gateway: {
@@ -306,7 +306,7 @@ describe("Unit test for: mw - cache", () => {
 				query: {},
 				soajs: {
 					tenant: { id: 'tenant-default-ttl' },
-					controller: { serviceParams: { name: 'test', serviceInfo: ['', 'test', 'test'] } },
+					controller: { serviceParams: { name: 'test', serviceInfo: ['', 'test', 'test'], isAPIPublic: true } },
 					registry: {
 						custom: {
 							gateway: {
@@ -345,7 +345,7 @@ describe("Unit test for: mw - cache", () => {
 				query: { page: '1', limit: '10' },
 				soajs: {
 					tenant: { id: 'tenant-query' },
-					controller: { serviceParams: { name: 'test', serviceInfo: ['', 'test', 'test'] } },
+					controller: { serviceParams: { name: 'test', serviceInfo: ['', 'test', 'test'], isAPIPublic: true } },
 					registry: {
 						custom: {
 							gateway: {
@@ -381,7 +381,7 @@ describe("Unit test for: mw - cache", () => {
 				query: {},
 				soajs: {
 					tenant: { id: 'tenant-empty-query' },
-					controller: { serviceParams: { name: 'test', serviceInfo: ['', 'test', 'test'] } },
+					controller: { serviceParams: { name: 'test', serviceInfo: ['', 'test', 'test'], isAPIPublic: true } },
 					registry: {
 						custom: {
 							gateway: {
@@ -453,6 +453,123 @@ describe("Unit test for: mw - cache", () => {
 			let functionMw = mw(mockConfig);
 			functionMw(req, res, (error) => {
 				assert.ifError(error);
+				done();
+			});
+		});
+	});
+
+	describe("scope handling (public vs private)", () => {
+		let noopRes = {
+			setHeader: function() {},
+			writeHead: function() { return this; },
+			write: function() { return true; },
+			end: function() {}
+		};
+
+		function buildReq(serviceParamsExtra, uracDriver, apiConfig) {
+			return {
+				method: 'GET',
+				query: {},
+				soajs: {
+					tenant: { id: 'tenant-scope' },
+					uracDriver: uracDriver,
+					controller: {
+						serviceParams: Object.assign({ name: 'test', serviceInfo: ['', 'test', 'test'] }, serviceParamsExtra)
+					},
+					registry: {
+						custom: {
+							gateway: {
+								value: {
+									cache: {
+										model: 'memory',
+										services: {
+											test: { enabled: true, apis: { 'GET /test': Object.assign({ enabled: true, ttl: 30000 }, apiConfig) } }
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			};
+		}
+
+		it("public API: should cache scoped to tenant only (no user in key)", (done) => {
+			let req = buildReq({ isAPIPublic: true }, { id: 'user-1' }, {});
+			let functionMw = mw(mockConfig);
+			functionMw(req, noopRes, (error) => {
+				assert.ifError(error);
+				assert.ok(req.soajs.cacheContext, 'cacheContext should be set on MISS');
+				assert.strictEqual(req.soajs.cacheContext.key.l1, 'tenant-scope');
+				assert.strictEqual(req.soajs.cacheContext.key.l2.indexOf(':u:'), -1, 'public key must not contain user part');
+				done();
+			});
+		});
+
+		it("private API: should default to tenant_user scope (user in key)", (done) => {
+			let req = buildReq({ isAPIPublic: false }, { id: 'user-1' }, {});
+			let functionMw = mw(mockConfig);
+			functionMw(req, noopRes, (error) => {
+				assert.ifError(error);
+				assert.ok(req.soajs.cacheContext, 'cacheContext should be set on MISS');
+				assert.notStrictEqual(req.soajs.cacheContext.key.l2.indexOf(':u:user-1'), -1, 'private key must contain user part');
+				done();
+			});
+		});
+
+		it("private API: different users get different cache keys", (done) => {
+			let functionMw = mw(mockConfig);
+			let reqA = buildReq({ isAPIPublic: false }, { id: 'user-A' }, {});
+			let reqB = buildReq({ isAPIPublic: false }, { id: 'user-B' }, {});
+			functionMw(reqA, noopRes, (errA) => {
+				assert.ifError(errA);
+				functionMw(reqB, noopRes, (errB) => {
+					assert.ifError(errB);
+					assert.notStrictEqual(reqA.soajs.cacheContext.key.l2, reqB.soajs.cacheContext.key.l2, 'different users must not share a key');
+					done();
+				});
+			});
+		});
+
+		it("private API without resolved user: should skip caching (no cacheContext)", (done) => {
+			let req = buildReq({ isAPIPublic: false }, null, {});
+			let functionMw = mw(mockConfig);
+			functionMw(req, noopRes, (error) => {
+				assert.ifError(error);
+				assert.strictEqual(req.soajs.cacheContext, undefined, 'must not set cacheContext when user is unresolved');
+				done();
+			});
+		});
+
+		it("scope override: private API forced to tenant scope", (done) => {
+			let req = buildReq({ isAPIPublic: false }, { id: 'user-1' }, { scope: 'tenant' });
+			let functionMw = mw(mockConfig);
+			functionMw(req, noopRes, (error) => {
+				assert.ifError(error);
+				assert.ok(req.soajs.cacheContext, 'cacheContext should be set on MISS');
+				assert.strictEqual(req.soajs.cacheContext.key.l2.indexOf(':u:'), -1, 'overridden tenant scope must not contain user part');
+				done();
+			});
+		});
+
+		it("scope override: public API forced to tenant_user scope", (done) => {
+			let req = buildReq({ isAPIPublic: true }, { id: 'user-1' }, { scope: 'tenant_user' });
+			let functionMw = mw(mockConfig);
+			functionMw(req, noopRes, (error) => {
+				assert.ifError(error);
+				assert.ok(req.soajs.cacheContext, 'cacheContext should be set on MISS');
+				assert.notStrictEqual(req.soajs.cacheContext.key.l2.indexOf(':u:user-1'), -1, 'overridden tenant_user scope must contain user part');
+				done();
+			});
+		});
+
+		it("invalid scope: should fall back to default (private -> tenant_user)", (done) => {
+			let req = buildReq({ isAPIPublic: false }, { id: 'user-1' }, { scope: 'bogus' });
+			let functionMw = mw(mockConfig);
+			functionMw(req, noopRes, (error) => {
+				assert.ifError(error);
+				assert.ok(req.soajs.cacheContext, 'cacheContext should be set on MISS');
+				assert.notStrictEqual(req.soajs.cacheContext.key.l2.indexOf(':u:user-1'), -1, 'invalid scope must fall back to tenant_user for private API');
 				done();
 			});
 		});


### PR DESCRIPTION
## Summary

GET response caching was keyed only by tenant id, so two users in the same tenant hitting a **private** GET shared one cache entry — allowing one user to be served another user's response (a cross-user data leak, not just staleness).

The cache now resolves a **scope** per API:

- **Public** APIs (no `access_token` required) → `tenant` scope (key = tenant id) — unchanged behavior
- **Private** APIs → `tenant_user` scope (key also includes the URAC user id)

The default is inferred from `req.soajs.controller.serviceParams.isAPIPublic` (already set upstream by the `mt` middleware and used by the traffic middleware). It can be overridden per API in the custom registry via a new `scope` field (`"tenant"` | `"tenant_user"`).

**Safety:** a `tenant_user` request with no resolved user is **not cached** — a misconfiguration becomes a cache miss, never a cross-user leak.

## Also included

`unref()` the periodic cleanup timers in the three in-memory models (`cache`, `idempotency`, `traffic`) so they no longer hold the Node event loop open. The unit suite now self-terminates without mocha's `--exit`.

## Tests

- 7 new unit tests covering public/private scoping, per-user key isolation, the safety skip, both override directions, and invalid-scope fallback.
- Existing cache tests updated to set `isAPIPublic`.
- **Unit:** 174 passing, 0 failing (self-exits).
- **Integration** (against live Mongo): 37 passing, 0 failing.

## Docs

`docs/middleware/cache.md` updated: new `scope` config field, public-vs-private scope section, safety behavior, and corrected cache-key structure / examples.