### PR TITLE
fix(idempotency): jshint lint fix for enforce ternary

### DIFF
--- a/mw/idempotency/index.js
+++ b/mw/idempotency/index.js
@@ -103,9 +103,7 @@ module.exports = function (configuration) {
 
 		// Request targets an idempotency-enabled and matched API. Resolve enforcement:
 		// service-level 'enforce' overrides the global default.
-		const enforce = (typeof serviceConfig.enforce === 'boolean')
-			? serviceConfig.enforce
-			: (idempotencyConfig.enforce === true);
+		const enforce = (typeof serviceConfig.enforce === 'boolean') ? serviceConfig.enforce : (idempotencyConfig.enforce === true);
 
 		if (!idempotencyKey) {
 			if (enforce) {


### PR DESCRIPTION
Follow-up to #28. The `enforce` ternary had a line break before `?` which jshint flags as a misleading line break (lint step failed CI on develop). Collapsed to a single line.

`grunt jshint` — 69 files lint free.