### PR TITLE
Check deviceId on the access token when authorising

### DIFF
--- a/docs/middleware/oauth.md
+++ b/docs/middleware/oauth.md
@@ -60,8 +60,35 @@ Uses oauth2-server library for token validation.
   │    bearerToken: user,   │
   │    type: 2              │
   │  }                      │
-  └─────────────────────────┘
+  └────────┬────────────────┘
+           │
+           ▼
+  ┌─────────────────────────┐
+  │  deviceId check         │ token user.deviceId vs device-id header
+  └────────┬────────────────┘
+           │
+           ├─── Mismatch ──▶ Error 156
+           │
+           ▼
+       next()
 ```
+
+#### deviceId check
+
+The access token record carries `user.deviceId`, set at login from the `device-id`
+header and carried forward across refreshes. It is matched against the `device-id`
+header on every private API call. The check runs on the record `authorise()` already
+fetched, so it costs no extra database call.
+
+The agent cannot be used for this, mobile sends the build number in the user-agent
+(ie: `democav/142 CFNetwork/3826.400.120 Darwin/24.3.0`) which changes on every build.
+
+Tokens with no `deviceId` are not checked. This covers tokens created before deviceId
+was introduced and clients that do not send the header at all, both get checked once
+the client logs in again with the header. A client that sends `device-id` on login but
+omits it on API calls is denied, the header has to be sent consistently.
+
+This check is only available for type 2, a type 0 JWT carries no stored token record.
 
 ### Type 0: JWT
 
@@ -155,6 +182,7 @@ Default OAuth service configuration:
 | Code | Description |
 |------|-------------|
 | 143 | Invalid or missing JWT token |
+| 156 | Device forbidden, the deviceId on the token does not match the device-id header |
 | OAuth2Error | Various OAuth2 errors (invalid_token, expired, etc.) |
 
 ## Properties Set

--- a/mw/oauth/index.js
+++ b/mw/oauth/index.js
@@ -32,9 +32,28 @@ module.exports = (configuration) => {
 	});
 	
 	let jwt = require('jsonwebtoken');
-	
+
+	/**
+	 * Matches the deviceId on the access token record against the device-id header.
+	 *
+	 * NOTE: we cannot check for agent, mobile is sending the build number
+	 *       (ie: "democav/142 CFNetwork/3826.400.120 Darwin/24.3.0") which changes on every build.
+	 *       we check deviceId instead. tokens with no deviceId (created before deviceId was
+	 *       introduced, or by a client that does not send the header) are not checked, they get
+	 *       checked once the client logs in again.
+	 *
+	 * @param req
+	 * @returns {boolean} true when the request is allowed to proceed
+	 */
+	let deviceIdMatch = (req) => {
+		if (!req.oauth || !req.oauth.bearerToken || !req.oauth.bearerToken.user || !req.oauth.bearerToken.user.deviceId) {
+			return true;
+		}
+		return req.oauth.bearerToken.user.deviceId === req.get('device-id');
+	};
+
 	return (req, res, next) => {
-		
+
 		let oauthType = 2;
 		let tenantOauth = req.soajs.tenantOauth;
 		if (tenantOauth && Object.hasOwnProperty.call(tenantOauth, 'type')) {
@@ -45,7 +64,18 @@ module.exports = (configuration) => {
 		
 		//0=oauth0, 2=oauth2
 		if (2 === oauthType) {
-			oauthObj.authorise()(req, res, next);
+			//NOTE: authorise() sets req.oauth.bearerToken to the token record it fetched from the
+			//		model, the deviceId check is done on it here to avoid fetching the token again.
+			oauthObj.authorise()(req, res, (error) => {
+				if (error) {
+					return next(error);
+				}
+				if (!deviceIdMatch(req)) {
+					req.soajs.log.debug("Access denied, deviceId mismatch [deviceId: " + req.get('device-id') + "]");
+					return next(156);
+				}
+				return next();
+			});
 		} else {
 			let algorithms = req.soajs.registry.serviceConfig.oauth.algorithms || ["HS256"];
 			let audience = req.soajs.registry.serviceConfig.oauth.audience || "";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soajs.controller",
   "description": "soajs multi tenant API gateway",
-  "version": "4.3.7",
+  "version": "4.3.8",
   "author": {
     "name": "soajs team",
     "email": "team@soajs.org"

--- a/test/unit/mw/oauth/index.js
+++ b/test/unit/mw/oauth/index.js
@@ -99,3 +99,119 @@ describe("Unit test for: mw - oauth", () => {
         });
     });
 });
+
+describe("Unit test for: mw - oauth deviceId check", () => {
+
+    // builds a configuration whose model returns an access token carrying the given deviceId
+    let buildConfiguration = (deviceId) => {
+        let user = {"id": "1"};
+        if (deviceId !== undefined) {
+            user.deviceId = deviceId;
+        }
+        return {
+            "soajs": {
+                "param": {}
+            },
+            "serviceConfig": {
+                "oauth": {
+                    grants: ["password", "refresh_token"],
+                    debug: false,
+                    accessTokenLifetime: 7200,
+                    refreshTokenLifetime: 1209600
+                }
+            },
+            "model": {
+                "getAccessToken": (bearerToken, cb) => {
+                    return cb(null, {
+                        "token": bearerToken,
+                        "expires": new Date(new Date().getTime() + 3600000),
+                        "user": user
+                    });
+                }
+            }
+        };
+    };
+
+    // oauthType 2 so that the access token is fetched from the model
+    let buildReq = (headerDeviceId) => {
+        return {
+            "soajs": {
+                "log": {
+                    "debug": () => {
+                    }
+                },
+                "tenantOauth": {
+                    "type": 2
+                },
+                "servicesConfig": {},
+                "registry": {
+                    "serviceConfig": {
+                        "oauth": {
+                            "type": 2
+                        }
+                    }
+                }
+            },
+            "query": {},
+            "body": {},
+            "get": (what) => {
+                if ('Authorization' === what) {
+                    return "Bearer anAccessToken";
+                }
+                if ('device-id' === what) {
+                    return headerDeviceId;
+                }
+                return undefined;
+            }
+        };
+    };
+    let res = {};
+
+    it("test oauth MW - deviceId matches", (done) => {
+        let functionMw = mw(buildConfiguration("2222222222"));
+        let req = buildReq("2222222222");
+        functionMw(req, res, (error) => {
+            assert.ifError(error);
+            assert.ok(req.oauth.bearerToken);
+            done();
+        });
+    });
+
+    it("test oauth MW - deviceId does not match", (done) => {
+        let functionMw = mw(buildConfiguration("3333333333"));
+        let req = buildReq("4444444444");
+        functionMw(req, res, (error) => {
+            assert.deepStrictEqual(error, 156);
+            done();
+        });
+    });
+
+    it("test oauth MW - deviceId on the token but no header", (done) => {
+        let functionMw = mw(buildConfiguration("3333333333"));
+        let req = buildReq(undefined);
+        functionMw(req, res, (error) => {
+            assert.deepStrictEqual(error, 156);
+            done();
+        });
+    });
+
+    it("test oauth MW - no deviceId on the token, check is skipped", (done) => {
+        let functionMw = mw(buildConfiguration(undefined));
+        let req = buildReq("5555555555");
+        functionMw(req, res, (error) => {
+            assert.ifError(error);
+            assert.ok(req.oauth.bearerToken);
+            done();
+        });
+    });
+
+    it("test oauth MW - null deviceId on the token, check is skipped", (done) => {
+        let functionMw = mw(buildConfiguration(null));
+        let req = buildReq("5555555555");
+        functionMw(req, res, (error) => {
+            assert.ifError(error);
+            assert.ok(req.oauth.bearerToken);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
soajs.oauth matches `deviceId` before refreshing a token (soajs/soajs.oauth#27). This does the same match on the access token, for every private API call.

## Where

`mw/oauth/index.js`, right after `authorise()` succeeds.

- `oauth2-server`'s `authorise()` sets `req.oauth.bearerToken` to the **full token record**, so `user.deviceId` is already in hand. No extra database call on the hot path.
- It cannot live in the model as originally sketched: `getAccessToken(bearerToken, cb)` has no request, so no access to the `device-id` header. Changing that signature would mean touching soajs.core.modules and its `oauth2-server` callers.
- In the middleware rather than in `mw/mt/utils.js oauthCheck` because `soajs.oauth()` is called from two places (`mw/mt/index.js:87` and `mw/mt/utils.js:477`) — this covers both.

## Behaviour

On mismatch, respond `156` Device forbidden (403). The code already existed and already mapped to 403. The token is **not** deleted: it is short lived, and the matching refresh call fails its own deviceId check, so the session dies on its own.

Tokens with no `deviceId` are not checked, they get checked once the client logs in again. Only type 2 is covered, a type 0 JWT carries no stored token record.

## Deployment note

This fires on **every** private API call, not just on refresh. A client that sends `device-id` at login but omits it on subsequent calls will be denied on everything. Clients that never send the header are unaffected, `deviceId` is `null` on their tokens so the check is skipped. Worth confirming mobile sends the header on all requests before this ships.

## Tests

5 new unit tests: match, mismatch, deviceId-on-token-but-no-header, no deviceId, null deviceId. The existing suite only covered the type 0 JWT path, so this is the first coverage of type 2; the model is stubbed rather than needing a live provision.

`docs/middleware/oauth.md` updated: type 2 flow diagram, a `deviceId check` subsection, and 156 in the error table.

Version bumped to 4.3.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)