### PR TITLE
Allow turning the deviceId check off at the custom registry

### DIFF
--- a/docs/configuration-custom-registry.md
+++ b/docs/configuration-custom-registry.md
@@ -27,6 +27,8 @@ registry.custom
 │       │       └── [service]       # Service-specific settings
 │       ├── maintenanceMode         # Gateway maintenance mode
 │       ├── lastSeen                # User activity tracking
+│       ├── oauth
+│       │   └── deviceIdCheck       # Turn the deviceId check off
 │       └── gotoService
 │           ├── monitor             # Request monitoring config
 │           └── renewReqMonitorOff  # Disable timeout renewal
@@ -448,6 +450,37 @@ Whitelists specific APIs that can be accessed when a user is PIN-locked (during 
 
 ---
 
+## 13. OAuth Device ID Check
+
+**Path:** `registry.custom.gateway.value.oauth.deviceIdCheck`
+
+**Middleware:** `mw/oauth/index.js`
+
+Turns off the deviceId check done when authorising an access token. The check matches
+`user.deviceId` on the access token record against the `device-id` header on every
+private API call, and denies with error 156 on mismatch.
+
+```javascript
+{
+  "oauth": {
+    "deviceIdCheck": false                   // Turn off the deviceId check
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `deviceIdCheck` | boolean | `true` | Set to `false` to turn the deviceId check off |
+
+Only the boolean `false` turns the check off. Any other value, and a missing or
+malformed entry, leaves it on.
+
+Note this is a `gateway` entry, not an `oauth` one. The `registry.custom.oauth.value.*`
+entries above are consumed by `mw/mt/utils.js` and `mw/gotoService/roaming.js`, this one
+is read by the oauth middleware itself.
+
+---
+
 ## Complete Configuration Example
 
 ```javascript
@@ -514,6 +547,9 @@ Whitelists specific APIs that can be accessed when a user is PIN-locked (during 
       "api": "/user/last/seen",
       "network": "production"
     },
+    "oauth": {
+      "deviceIdCheck": false
+    },
     "gotoService": {
       "monitor": {
         "blacklist": ["soamonitor", "urac"]
@@ -565,6 +601,7 @@ Custom registry configurations are processed in this order:
 | 4 | gotoService/preRedirect | `gotoService.renewReqMonitorOff` |
 | 5 | gotoService/redirectToService | `gotoService.monitor` |
 | 6 | mt (security checks) | `mt.whitelist`, `oauth.value.pinWrapper`, `oauth.value.pinWhitelist` |
+| 6a | oauth (called from mt) | `oauth.deviceIdCheck` |
 | 7 | idempotency | `idempotency.model`, `idempotency.services.[name]` |
 | 8 | traffic | `traffic.model`, `traffic.throttling` |
 | 9 | cache | `cache.model`, `cache.defaultTTL`, `cache.services.[name]` |

--- a/docs/middleware/oauth.md
+++ b/docs/middleware/oauth.md
@@ -90,6 +90,23 @@ omits it on API calls is denied, the header has to be sent consistently.
 
 This check is only available for type 2, a type 0 JWT carries no stored token record.
 
+##### Turning it off
+
+The check is on by default. To turn it off for an environment, set `deviceIdCheck` to
+`false` under the `gateway` custom registry entry:
+
+```json
+{
+  "oauth": {
+    "deviceIdCheck": false
+  }
+}
+```
+
+Read from `registry.custom.gateway.value.oauth.deviceIdCheck`. Only the boolean `false`
+turns it off, any other value leaves it on, so a missing or malformed entry keeps the
+check running.
+
 ### Type 0: JWT
 
 Uses jsonwebtoken library for JWT validation.

--- a/mw/oauth/index.js
+++ b/mw/oauth/index.js
@@ -34,6 +34,32 @@ module.exports = (configuration) => {
 	let jwt = require('jsonwebtoken');
 
 	/**
+	 * The deviceId check is on unless it is explicitly turned off at the custom registry.
+	 * Anything other than false leaves it on.
+	 *
+	 * req.soajs.registry.custom.gateway.value.oauth
+	 * {
+		  "oauth": {
+			"deviceIdCheck": false
+		  }
+		}
+	 *
+	 * @param req
+	 * @returns {boolean} true when the check is turned on
+	 */
+	let deviceIdCheckOn = (req) => {
+		if (req.soajs.registry &&
+			req.soajs.registry.custom &&
+			req.soajs.registry.custom.gateway &&
+			req.soajs.registry.custom.gateway.value &&
+			req.soajs.registry.custom.gateway.value.oauth &&
+			req.soajs.registry.custom.gateway.value.oauth.deviceIdCheck === false) {
+			return false;
+		}
+		return true;
+	};
+
+	/**
 	 * Matches the deviceId on the access token record against the device-id header.
 	 *
 	 * NOTE: we cannot check for agent, mobile is sending the build number
@@ -46,6 +72,9 @@ module.exports = (configuration) => {
 	 * @returns {boolean} true when the request is allowed to proceed
 	 */
 	let deviceIdMatch = (req) => {
+		if (!deviceIdCheckOn(req)) {
+			return true;
+		}
 		if (!req.oauth || !req.oauth.bearerToken || !req.oauth.bearerToken.user || !req.oauth.bearerToken.user.deviceId) {
 			return true;
 		}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soajs.controller",
   "description": "soajs multi tenant API gateway",
-  "version": "4.3.8",
+  "version": "4.3.9",
   "author": {
     "name": "soajs team",
     "email": "team@soajs.org"

--- a/test/unit/mw/oauth/index.js
+++ b/test/unit/mw/oauth/index.js
@@ -214,4 +214,56 @@ describe("Unit test for: mw - oauth deviceId check", () => {
             done();
         });
     });
+
+    // turns the check off at registry.custom.gateway.value.oauth
+    let turnCheckOff = (req, deviceIdCheck) => {
+        req.soajs.registry.custom = {
+            "gateway": {
+                "value": {
+                    "oauth": {
+                        "deviceIdCheck": deviceIdCheck
+                    }
+                }
+            }
+        };
+        return req;
+    };
+
+    it("test oauth MW - deviceId mismatch but check turned off at registry", (done) => {
+        let functionMw = mw(buildConfiguration("3333333333"));
+        let req = turnCheckOff(buildReq("4444444444"), false);
+        functionMw(req, res, (error) => {
+            assert.ifError(error);
+            assert.ok(req.oauth.bearerToken);
+            done();
+        });
+    });
+
+    it("test oauth MW - deviceId mismatch and check explicitly turned on at registry", (done) => {
+        let functionMw = mw(buildConfiguration("3333333333"));
+        let req = turnCheckOff(buildReq("4444444444"), true);
+        functionMw(req, res, (error) => {
+            assert.deepStrictEqual(error, 156);
+            done();
+        });
+    });
+
+    it("test oauth MW - only false turns the check off, not a truthy value", (done) => {
+        let functionMw = mw(buildConfiguration("3333333333"));
+        let req = turnCheckOff(buildReq("4444444444"), "false");
+        functionMw(req, res, (error) => {
+            assert.deepStrictEqual(error, 156);
+            done();
+        });
+    });
+
+    it("test oauth MW - empty custom registry leaves the check on", (done) => {
+        let functionMw = mw(buildConfiguration("3333333333"));
+        let req = buildReq("4444444444");
+        req.soajs.registry.custom = {};
+        functionMw(req, res, (error) => {
+            assert.deepStrictEqual(error, 156);
+            done();
+        });
+    });
 });


### PR DESCRIPTION
Follow up to #32. That check fires on **every** private API call, so there needs to be a way to turn it off for an environment without a redeploy.

## Config

`registry.custom.gateway.value.oauth.deviceIdCheck`

```json
{
  "oauth": {
    "deviceIdCheck": false
  }
}
```

## Behaviour

**Fail-secure.** Only the boolean `false` turns the check off. A missing entry, an empty `custom`, or a truthy/string value such as `"false"` all leave it running — a typo in the registry should not silently disable a security check.

Read with an explicit `&&` chain rather than the `getConfig` helper in `mw/mt/utils.js`, which is local to that file and not exported. The explicit chain matches how `mw/gotoService/roaming.js` and `oauthCheck` already read custom registry values.

## Naming wrinkle

This is a **`gateway`** entry (`custom.gateway.value.oauth`), which sits next to the pre-existing and separate **`custom.oauth.value.*`** entries used for roaming and PIN config. Putting `deviceIdCheck` in the latter would read as `undefined` and the check would stay on, so the distinction is called out in the docs.

## Tests

4 new unit tests: turned off, explicitly turned on, truthy-but-not-`false`, and empty `custom`. 14 passing in the oauth mw suite.

## Docs

- `docs/configuration-custom-registry.md` — section 13, structure tree, complete configuration example, and a row in the processing order table.
- `docs/middleware/oauth.md` — a "Turning it off" subsection.

Version bumped to 4.3.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)