### PR TITLE
Fix undefined monitor host, guard log payload building, add redacted error context

### DIFF
--- a/mw/awareness/ha.js
+++ b/mw/awareness/ha.js
@@ -176,7 +176,9 @@ let lib = {
 				}, function () {
 					awarenessCache = myCache;
 					param.log.debug("Awareness cache rebuilt successfully");
-					param.log.debug(JSON.stringify(awarenessCache));
+					if (param.log.debug()) {
+						param.log.debug(JSON.stringify(awarenessCache));
+					}
 
 					let cacheTTL = registryModule.get().serviceConfig.awareness.cacheTTL;
 					if (cacheTTL) {

--- a/mw/gotoService/index.js
+++ b/mw/gotoService/index.js
@@ -82,7 +82,9 @@ module.exports = (configuration) => {
 						req.soajs.registry.services[service_n]) {
 						req.soajs.log.debug(req.soajs.registry.services[service_n]);
 					}
-					req.soajs.log.warn(JSON.stringify({ "url": req.url, "headers": req.headers }));
+					if (req.soajs.log.warn()) {
+						req.soajs.log.warn(JSON.stringify({ "url": req.url, "headers": req.headers }));
+					}
 					return req.soajs.controllerResponse(core.error.getError(130));
 				}
 

--- a/mw/gotoService/lib/preRedirect.js
+++ b/mw/gotoService/lib/preRedirect.js
@@ -28,14 +28,16 @@ module.exports = (req, res, core, cb) => {
 		return req.soajs.controllerResponse(core.error.getError(131));
 	}
 	let nextStep = function (host, port, fullURI) {
-		req.soajs.log.info(JSON.stringify({
-			"serviceName": restServiceParams.name,
-			"host": host,
-			"version": restServiceParams.version,
-			"url": restServiceParams.url,
-			"port": restServiceParams.registry.port,
-			"header": req.headers
-		}));
+		if (req.soajs.log.info()) {
+			req.soajs.log.info(JSON.stringify({
+				"serviceName": restServiceParams.name,
+				"host": host,
+				"version": restServiceParams.version,
+				"url": restServiceParams.url,
+				"port": restServiceParams.registry.port,
+				"header": req.headers
+			}));
+		}
 
 		let requestTOR = restServiceParams.registry.requestTimeoutRenewal || config.requestTimeoutRenewal;
 		let requestTO = restServiceParams.registry.requestTimeout || config.requestTimeout;

--- a/mw/gotoService/redirectToService.js
+++ b/mw/gotoService/redirectToService.js
@@ -225,7 +225,7 @@ module.exports = (configuration) => {
 			if (monitor && !monitor_service_blacklist && monitor.req_info) {
 				monitoObj.port = req.soajs.controller.serviceParams.registry.port;
 				monitoObj.url = req.soajs.controller.serviceParams.url;
-				monitoObj.host = req.host;
+				monitoObj.host = obj.host;
 			}
 			if (monitor && !monitor_service_blacklist && monitor.req_header) {
 				monitoObj.headers = req.headers;

--- a/mw/url/index.js
+++ b/mw/url/index.js
@@ -64,7 +64,9 @@ module.exports = (configuration) => {
 				!req.soajs.registry.services[req.soajs.controller.serviceParams.service_n]
 			)) {
 			req.soajs.log.fatal("Service [" + req.soajs.controller.serviceParams.service_n + "] URL [" + req.url + "] couldn't be matched to a service or the service entry in registry is missing [port || hosts]");
-			req.soajs.log.warn(JSON.stringify({ "url": req.url, "headers": req.headers }));
+			if (req.soajs.log.warn()) {
+				req.soajs.log.warn(JSON.stringify({ "url": req.url, "headers": req.headers }));
+			}
 			return req.soajs.controllerResponse(core.error.getError(130));
 		}
 

--- a/test/unit/utilities/utils.js
+++ b/test/unit/utilities/utils.js
@@ -1,9 +1,81 @@
 "use strict"
+const assert = require('assert');
 const helper = require("../../helper.js");
 
 let utils = helper.requireModule('./utilities/utils.js');
 
 describe("Testing utilities", () => {
+
+	const TOKEN = "e2d0ffb0f0e34bd6a8e0a0b4a1d1b6c1f2a3b4c5";
+	const EKEY = "aa39b5490c4a4ed0e56d7ec1232a428f771e8bb83cfcee16de14f735d0f5da58";
+	const IKEY = "38145c67717c73d3febd16df38abf311";
+
+	let logged = {
+		"error": [],
+		"warn": []
+	};
+
+	/**
+	 * bunyan semantics: log.<level>() with no argument returns whether that level is
+	 * enabled, log.<level>(input) writes the record. The gateway relies on the first
+	 * form to skip building log payloads that would be discarded.
+	 */
+	let makeLog = (enabled) => {
+		return {
+			error: (input) => {
+				if (input === undefined) {
+					return enabled;
+				}
+				logged.error.push(input);
+			},
+			warn: (input) => {
+				if (input === undefined) {
+					return enabled;
+				}
+				logged.warn.push(input);
+			}
+		};
+	};
+
+	let makeReq = (enabled) => {
+		return {
+			method: "GET",
+			url: "/urac/user/getprofile?access_token=" + TOKEN + "&key=" + EKEY + "&id=42",
+			headers: {
+				"access_token": TOKEN,
+				"key": EKEY,
+				"authorization": "Bearer " + TOKEN
+			},
+			getClientIP: () => {
+				return "196.218.44.17";
+			},
+			getClientUserAgent: () => {
+				return "mocha-agent";
+			},
+			soajs: {
+				log: makeLog(enabled),
+				controller: {
+					serviceParams: {
+						name: "urac",
+						version: "3",
+						parsedUrl: { pathname: "/urac/user/getprofile" }
+					}
+				},
+				tenant: {
+					id: "5c0e74ba9acc3c5a84a51259",
+					code: "TSTM",
+					key: { iKey: IKEY, eKey: EKEY },
+					application: { product: "TPROD", package: "TPROD_BASIC" }
+				},
+				buildResponse: (input) => {
+					return input;
+				},
+				controllerResponse: (input) => {
+					return input;
+				}
+			}
+		};
+	};
 
 	let res = {
 		status: () => {
@@ -18,24 +90,12 @@ describe("Testing utilities", () => {
 		}
 	};
 
-	let req = {
-		soajs: {
-			log: {
-				error: (input) => {
-					// console.error(input);
-				},
-				warn: (input) => {
-					// console.error(input);
-				}
-			},
-			buildResponse: (input) => {
-				return input;
-			},
-			controllerResponse: (input) => {
-				return input;
-			}
-		}
-	};
+	let req = makeReq(true);
+
+	beforeEach(() => {
+		logged.error = [];
+		logged.warn = [];
+	});
 
 	it("logErrors - number error", (done) => {
 		utils.logErrors(123, req, res, (error) => {
@@ -74,6 +134,96 @@ describe("Testing utilities", () => {
 	});
 	it("controllerErrorHandler - with error", (done) => {
 		utils.controllerErrorHandler({ "code": 200, "msg": "dummy200" }, req, res, null);
+		done();
+	});
+
+	it("controllerErrorHandler - emits the redacted context at error level", (done) => {
+		let r = makeReq(true);
+		utils.controllerErrorHandler({ "code": 401, "msg": "The access token provided is invalid." }, r, res, null);
+
+		assert.strictEqual(logged.error.length, 1);
+		let ctx = JSON.parse(logged.error[0]);
+		assert.strictEqual(ctx.code, 401);
+		assert.strictEqual(ctx.msg, "The access token provided is invalid.");
+		assert.strictEqual(ctx.method, "GET");
+		assert.strictEqual(ctx.service, "urac");
+		assert.strictEqual(ctx.version, "3");
+		assert.strictEqual(ctx.api, "/urac/user/getprofile");
+		assert.strictEqual(ctx.ip, "196.218.44.17");
+		assert.strictEqual(ctx.ua, "mocha-agent");
+		assert.deepStrictEqual(ctx.tenant, { "id": "5c0e74ba9acc3c5a84a51259", "code": "TSTM" });
+		assert.strictEqual(ctx.iKey, IKEY);
+		assert.deepStrictEqual(ctx.application, { "product": "TPROD", "package": "TPROD_BASIC" });
+		done();
+	});
+
+	it("controllerErrorHandler - masks credentials and never logs headers", (done) => {
+		let r = makeReq(true);
+		utils.controllerErrorHandler({ "code": 401, "msg": "bad token" }, r, res, null);
+
+		let line = logged.error[0];
+		assert.strictEqual(line.indexOf(TOKEN), -1, "access_token leaked into the error context");
+		assert.strictEqual(line.indexOf(EKEY), -1, "eKey leaked into the error context");
+		assert.strictEqual(line.indexOf("authorization"), -1, "headers leaked into the error context");
+
+		let ctx = JSON.parse(line);
+		assert.strictEqual(ctx.url, "/urac/user/getprofile?access_token=***&key=***&id=42");
+		done();
+	});
+
+	it("controllerErrorHandler - numeric error resolves code and message", (done) => {
+		let r = makeReq(true);
+		utils.controllerErrorHandler(143, r, res, null);
+
+		let ctx = JSON.parse(logged.error[0]);
+		assert.strictEqual(ctx.code, 143);
+		assert.strictEqual(ctx.msg, "invalid_request: Malformed auth header");
+		done();
+	});
+
+	it("controllerErrorHandler - includes the resolved username when present", (done) => {
+		let r = makeReq(true);
+		r.soajs.uracDriver = { "username": "owner" };
+		utils.controllerErrorHandler({ "code": 401, "msg": "bad token" }, r, res, null);
+
+		let ctx = JSON.parse(logged.error[0]);
+		assert.strictEqual(ctx.username, "owner");
+		done();
+	});
+
+	it("controllerErrorHandler - degraded request without tenant or serviceParams", (done) => {
+		let r = makeReq(true);
+		r.soajs.controller = {};
+		delete r.soajs.tenant;
+		utils.controllerErrorHandler(130, r, res, null);
+
+		let ctx = JSON.parse(logged.error[0]);
+		assert.strictEqual(ctx.service, null);
+		assert.strictEqual(ctx.version, null);
+		assert.strictEqual(ctx.api, null);
+		assert.strictEqual(ctx.tenant, undefined);
+		assert.strictEqual(ctx.iKey, undefined);
+		assert.strictEqual(ctx.application, undefined);
+		done();
+	});
+
+	it("controllerErrorHandler - skips both payloads when the levels are off", (done) => {
+		let r = makeReq(false);
+		utils.controllerErrorHandler({ "code": 401, "msg": "bad token" }, r, res, null);
+
+		assert.strictEqual(logged.error.length, 0);
+		assert.strictEqual(logged.warn.length, 0);
+		done();
+	});
+
+	it("controllerErrorHandler - the warn dump still carries the raw headers", (done) => {
+		let r = makeReq(true);
+		utils.controllerErrorHandler({ "code": 401, "msg": "bad token" }, r, res, null);
+
+		assert.strictEqual(logged.warn.length, 1);
+		let dump = JSON.parse(logged.warn[0]);
+		assert.strictEqual(dump.headers.access_token, TOKEN);
+		assert.strictEqual(dump.url, r.url);
 		done();
 	});
 });

--- a/utilities/utils.js
+++ b/utilities/utils.js
@@ -11,6 +11,72 @@
 const coreModules = require("soajs.core.modules");
 let core = coreModules.core;
 
+//NOTE: credentials that must never reach the logs, they are masked in the query string
+const SENSITIVE_QS = /([?&](?:access_token|refresh_token|key)=)[^&]*/gi;
+
+/**
+ * Mask credentials in a url query string
+ *
+ * @param url
+ * @returns {string|null}
+ */
+function redactUrl(url) {
+    return url ? url.replace(SENSITIVE_QS, '$1***') : null;
+}
+
+/**
+ * Build a compact and redacted context for an error response.
+ * NOTE: headers are never included, they carry access_token, key, authorization and soajsinjectobj.
+ *
+ * @param err
+ * @param req
+ * @returns {Object}
+ */
+function errorContext(err, req) {
+    let soajs = req.soajs || {};
+    let serviceParams = (soajs.controller && soajs.controller.serviceParams) || {};
+    let tenant = soajs.tenant || {};
+
+    let code = null;
+    let msg = null;
+    if (typeof err === "number") {
+        code = err;
+        msg = core.error.generate(err).message;
+    } else if (err && typeof err === "object") {
+        code = err.code || err.status || null;
+        msg = err.msg || err.message || null;
+    }
+
+    let context = {
+        "code": code,
+        "msg": msg,
+        "method": req.method,
+        "service": serviceParams.name || serviceParams.service_n || null,
+        "version": serviceParams.version || null,
+        "api": (serviceParams.parsedUrl && serviceParams.parsedUrl.pathname) || null,
+        "url": redactUrl(req.url),
+        "ip": req.getClientIP ? req.getClientIP() : null,
+        "ua": req.getClientUserAgent ? req.getClientUserAgent() : null
+    };
+    if (tenant.id) {
+        context.tenant = { "id": tenant.id, "code": tenant.code };
+    }
+    //NOTE: iKey only, the eKey is the credential the client authenticates with
+    if (tenant.key && tenant.key.iKey) {
+        context.iKey = tenant.key.iKey;
+    }
+    if (tenant.application) {
+        context.application = {
+            "product": tenant.application.product,
+            "package": tenant.application.package
+        };
+    }
+    if (soajs.uracDriver && soajs.uracDriver.username) {
+        context.username = soajs.uracDriver.username;
+    }
+    return context;
+}
+
 //-------------------------- ERROR Handling MW - service & controller
 /**
  *
@@ -77,7 +143,13 @@ function controllerClientErrorHandler(err, req, res, next) {
  */
 function controllerErrorHandler(err, req, res, next) {
 
-    req.soajs.log.warn(JSON.stringify({ "url": req.url, "headers": req.headers }));
+    if (req.soajs.log.error()) {
+        req.soajs.log.error(JSON.stringify(errorContext(err, req)));
+    }
+    //NOTE: the full header dump stays at warn, it is a debugging aid and it is not redacted
+    if (req.soajs.log.warn()) {
+        req.soajs.log.warn(JSON.stringify({ "url": req.url, "headers": req.headers }));
+    }
 
     if (err.code && err.msg) {
         err.status = err.status || 500;


### PR DESCRIPTION
## Summary

Three related fixes in the gateway's monitoring and logging path.

### 1. `monitoObj.host` was always `undefined`

`redirectToService.js` set the monitor host from `req.host`. The gateway runs on `connect` over a raw `http.createServer`, not Express, and nothing in the middleware stack assigns `req.host` — so every record sent to soamonitor carried an undefined host.

`preRedirect` already resolves the upstream host (via `awareness.getHost`, or the endpoint `src.url`) and returns it in its callback object, which `redirectToService` receives but only reads `uri`/`config` from. Now uses `obj.host`. Makes per-replica latency attribution possible.

### 2. Log payloads were built and then discarded

Five sites called `JSON.stringify` unconditionally as an argument to `log.info/warn/debug`. Arguments evaluate eagerly, so under the production logger config the payload was built every time and then dropped by bunyan.

| File | Level | Frequency |
|---|---|---|
| `mw/gotoService/lib/preRedirect.js:31` | info | every proxied request |
| `utilities/utils.js` | warn | per error response |
| `mw/gotoService/index.js:85` | warn | unmatched service |
| `mw/url/index.js:67` | warn | unknown service |
| `mw/awareness/ha.js:179` | debug | per cache rebuild |

Guarded with the no-argument bunyan level check. Measured 1933 ns/call before, 4 ns after. Only `preRedirect` is on the hot path; at 1k req/s that is ~0.2% of one core and ~1.25 MB/s of allocation. Small in absolute terms, but it was pure waste. Output at info/debug is unchanged.

Verified the guard actually gates under the deployed config `{src: true, level: "error", gke: true}` — `createStream()` carries no level of its own, so bunyan applies the top-level `error` and the checks return false.

### 3. Auth failures were unattributable

A rejected `access_token` produced exactly one production line:

```
The access token provided is invalid.
```

No url, service, api, tenant, key or client ip. The only line carrying that context is the header dump in `controllerErrorHandler`, which sits at `warn` and never reaches production logs. A token-guessing attempt or an expired-token storm was neither in soamonitor (the request dies in `mt`, before dispatch) nor attributable in the logs.

Adds `errorContext()`, emitted at error level from `controllerErrorHandler` so it covers every error response:

```json
{"code":401,"msg":"The access token provided is invalid.","method":"GET",
 "service":"urac","version":"3","api":"/urac/user/getprofile",
 "url":"/urac/user/getprofile?access_token=***&key=***&id=42",
 "ip":"196.218.44.17","ua":"Mozilla/5.0 ...",
 "tenant":{"id":"5c0e74ba9acc3c5a84a51259","code":"TSTM"},
 "iKey":"38145c67717c73d3febd16df38abf311",
 "application":{"product":"TPROD","package":"TPROD_BASIC"}}
```

Handles all three error shapes the chain produces: numeric code (`next(143)`), `OAuth2Error`, and soajs `{code,msg}`.

**Redaction:** headers are never included — they carry `access_token`, `key`, `authorization` and `soajsinjectobj`. The url masks `access_token`, `refresh_token` and `key`. `tenant.iKey` is logged, never the `eKey`. The raw header dump stays at `warn` as a debugging aid.

## Testing

`grunt` lint clean (69 files). `grunt test` 197 passing, up from 190.

The existing log mock defined `error: (input) => {}`, returning `undefined`, so the guards short-circuited and the new path would never have been exercised. The mock now follows bunyan semantics — no-argument form returns the enabled flag — and records what is written.

Seven new cases: full field set, credential masking and header exclusion, numeric code resolution, `uracDriver.username`, a degraded request with no tenant or serviceParams, the level gate, and the warn dump remaining intact.

Mutation-checked both new behaviours:

| Mutation | Caught by |
|---|---|
| `redactUrl` returns the url unchanged | *masks credentials and never logs headers* |
| `if (log.error())` → `if (true)` | *skips both payloads when the levels are off* |

## Not included

Left deliberately, happy to follow up:

- `mw/key/index.js:25` logs the raw external key at error level
- soamonitor gets no record for pre-dispatch failures (auth, ACL, throttle) or cache hits
- no `statusCode` on either side, so a 500 is indistinguishable from a 200
- `monitor.req_response` gates whether the document is sent at all, not just body capture
- SIGTERM discards the monitor buffer instead of flushing it
- `redirectToService.js:276-283` regex-matches `content-length` against a content-type pattern, so `time.req_body` never computes