### PR TITLE
Raise operational failures to error, lower a deprecation notice

### DIFF
--- a/lib/logOnce.js
+++ b/lib/logOnce.js
@@ -1,0 +1,45 @@
+'use strict';
+
+/**
+ * @license
+ * Copyright SOAJS All Rights Reserved.
+ *
+ * Use of this source code is governed by an Apache license that can be
+ * found in the LICENSE file at the root of this repository
+ */
+
+const reported = new Set();
+
+/**
+ * Log a message once per distinct key.
+ *
+ * Static misconfiguration is discovered inside the request path, so reporting it
+ * normally would repeat on every request for the lifetime of the process. The
+ * condition cannot resolve itself without a registry change, so the first report
+ * carries all the information the rest would.
+ *
+ * @param log    the soajs logger
+ * @param level  one of the logger levels, ex: error
+ * @param key    identifies the condition, repeats with the same key are dropped
+ * @param message
+ */
+function logOnce(log, level, key, message) {
+	if (reported.has(key)) {
+		return false;
+	}
+	if (!log || typeof log[level] !== "function") {
+		return false;
+	}
+	reported.add(key);
+	log[level](message);
+	return true;
+}
+
+/**
+ * Forget what has been reported. Used by the unit tests.
+ */
+function resetLogOnce() {
+	reported.clear();
+}
+
+module.exports = { logOnce, resetLogOnce };

--- a/mw/awareness/custom.js
+++ b/mw/awareness/custom.js
@@ -145,7 +145,7 @@ let awareness_healthCheck = function (core, log) {
 
 					let stopLoggingAfter = registry.serviceConfig.awareness.maxLogCount;
 					if (statusObj.downCount <= stopLoggingAfter) {
-						log.warn("Self Awareness health check for service [" + sObj.name + "] for host [" + sObj.host + "] is NOT healthy");
+						log.error("Self Awareness health check for service [" + sObj.name + "] for host [" + sObj.host + "] is NOT healthy");
 					}
 					if (serviceAwarenessObj[sObj.name].healthy[sObj.version].indexOf(sObj.host) !== -1) {
 						//TODO: if we guarantee uniqueness we will not need the for loop
@@ -192,7 +192,7 @@ let awareness_healthCheck = function (core, log) {
 			}
 		}, function (err) {
 			if (err) {
-				log.warn('Unable to build awareness structure for services: ' + err);
+				log.error('Unable to build awareness structure for services: ' + err);
 			}
 		});
 	setTimeout(() => {

--- a/mw/awarenessEnv/custom.js
+++ b/mw/awarenessEnv/custom.js
@@ -26,7 +26,7 @@ let fetchControllerHosts = function (core, log, next) {
 	registry = registryModule.get();
 	registryModule.loadOtherEnvControllerHosts(gatewayServiceName, function (error, hosts) {
 		if (error) {
-			log.warn("Failed to load controller hosts. reusing from previous load. Reason: " + error.message);
+			log.error("Failed to load controller hosts. reusing from previous load. Reason: " + error.message);
 		} else {
 			controllerHosts = hosts;
 		}
@@ -107,7 +107,7 @@ let awareness_healthCheck = function (core, log) {
 					// });
 				}, function (err) {
 					if (err) {
-						log.warn('Unable to build awareness ENV structure for controllers: ' + err);
+						log.error('Unable to build awareness ENV structure for controllers: ' + err);
 					}
 				});
 		}

--- a/mw/cache/index.js
+++ b/mw/cache/index.js
@@ -12,6 +12,7 @@ const crypto = require('crypto');
 const get = (p, o) => p.reduce((xs, x) => (xs && xs[x]) ? xs[x] : null, o);
 const memory = require('./model/memory.js');
 const mongo = require('./model/mongo.js');
+const { logOnce } = require('../../lib/logOnce.js');
 
 let model = { memory, mongo };
 
@@ -102,7 +103,8 @@ module.exports = function (configuration) {
 
 		const modelType = cacheConfig.model || 'memory';
 		if (!model[modelType]) {
-			configuration.log.warn('Cache: Unknown model [' + modelType + ']. It can only be [memory || mongo]');
+			logOnce(configuration.log, "error", "cache_model_" + modelType,
+				'Cache: Unknown model [' + modelType + ']. It can only be [memory || mongo]. Caching is off.');
 			return next();
 		}
 
@@ -119,7 +121,8 @@ module.exports = function (configuration) {
 		let scope = apiConfig.scope;
 		if (scope !== 'tenant' && scope !== 'tenant_user') {
 			if (scope) {
-				configuration.log.warn('Cache: Unknown scope [' + scope + '] for API [' + method + ' ' + apiPath + ']. It can only be [tenant || tenant_user]. Falling back to default.');
+				logOnce(configuration.log, "error", "cache_scope_" + scope + "_" + method + "_" + apiPath,
+					'Cache: Unknown scope [' + scope + '] for API [' + method + ' ' + apiPath + ']. It can only be [tenant || tenant_user]. Falling back to default.');
 			}
 			scope = isAPIPublic ? 'tenant' : 'tenant_user';
 		}

--- a/mw/gotoService/index.js
+++ b/mw/gotoService/index.js
@@ -50,7 +50,7 @@ module.exports = (configuration) => {
 			//create proxy info object before calling extractbuildparams
 			let proxy = false;
 			if (serviceInfo[1] === 'proxy' && serviceInfo[2] === 'redirect') {
-				req.soajs.log.error("Route: [/proxy/redirect] is deprecated. You should use [/soajs/proxy].");
+				req.soajs.log.info("Route: [/proxy/redirect] is deprecated. You should use [/soajs/proxy].");
 				proxy = true;
 			} else if (serviceInfo[1] === 'soajs' && serviceInfo[2] === 'proxy') {
 				proxy = true;

--- a/mw/gotoService/redirectToService.js
+++ b/mw/gotoService/redirectToService.js
@@ -81,7 +81,8 @@ function flushMonitorBuffer() {
 				}
 			})
 			.catch((error) => {
-				req.soajs.log.debug('Monitor buffer flush failed: ' + error.message);
+				//NOTE: the buffer was already cleared, these items are lost
+				req.soajs.log.error('Monitor buffer flush failed, ' + itemsToSend.length + ' items lost: ' + error.message);
 			});
 	});
 }

--- a/mw/idempotency/index.js
+++ b/mw/idempotency/index.js
@@ -11,6 +11,7 @@
 const get = (p, o) => p.reduce((xs, x) => (xs && xs[x]) ? xs[x] : null, o);
 const memory = require('./model/memory.js');
 const mongo = require('./model/mongo.js');
+const { logOnce } = require('../../lib/logOnce.js');
 
 let model = { memory, mongo };
 
@@ -119,7 +120,8 @@ module.exports = function (configuration) {
 
 		const modelType = idempotencyConfig.model || 'memory';
 		if (!model[modelType]) {
-			configuration.log.warn('Idempotency: Unknown model [' + modelType + ']. It can only be [memory || mongo]');
+			logOnce(configuration.log, "error", "idempotency_model_" + modelType,
+				'Idempotency: Unknown model [' + modelType + ']. It can only be [memory || mongo]. Idempotency is off.');
 			return next();
 		}
 

--- a/mw/mt/index.js
+++ b/mw/mt/index.js
@@ -330,7 +330,9 @@ module.exports = (configuration) => {
 															return callback();
 														});
 													} else {
-														req.soajs.log.debug(serviceName + " interConnect failed for [" + item.name + "@" + item.version + "]");
+														//NOTE: the peer is dropped from the injected address book, the calling
+														//		service will behave as if it was never configured
+														req.soajs.log.error(serviceName + " interConnect failed for [" + item.name + "@" + item.version + "], peer dropped from awareness");
 														return callback();
 													}
 												});

--- a/mw/traffic/index.js
+++ b/mw/traffic/index.js
@@ -12,6 +12,7 @@
 const get = (p, o) => p.reduce((xs, x) => (xs && xs[x]) ? xs[x] : null, o);
 const memory = require('./model/memory.js');
 const mongo = require('./model/mongo.js');
+const { logOnce } = require('../../lib/logOnce.js');
 
 let model = {
 	memory, mongo
@@ -175,7 +176,8 @@ module.exports = function (configuration) {
 				if (trafficModel) {
 					throttling.model = trafficModel;
 					if (!model[throttling.model]) {
-						req.soajs.log.warn('Throttling:', 'Unkown model [' + throttling.model + ']. It can only be [memory || mongo]');
+						logOnce(req.soajs.log, "error", "throttling_model_" + throttling.model,
+							'Throttling: Unknown model [' + throttling.model + ']. It can only be [memory || mongo]. Throttling is off.');
 						return next();
 					}
 				}

--- a/server/controller.js
+++ b/server/controller.js
@@ -74,7 +74,7 @@ Controller.prototype.init = function (callback) {
 			let log = core.getLogger(_self.soajs.param.init.serviceName, registry.serviceConfig.logger);
 			if (service.fetched) {
 				if (!service.fetched.result) {
-					log.warn("Unable to find the service host ip. The service will NOT be registered for awareness.");
+					log.error("Unable to find the service host ip. The service will NOT be registered for awareness.");
 					log.info("IPs found: ", service.fetched.extra.ips);
 					log.warn("The default service IP has been used [" + service.ip + "]");
 				} else {
@@ -316,7 +316,7 @@ Controller.prototype.start = function (registry, log, service, server, serverMai
 								});
 							});
 						} else {
-							log.warn("Unable to register host IP [" + service.ip + "] for service [" + _self.soajs.param.init.serviceName + "@" + _self.soajs.param.init.serviceVersion + "]");
+							log.error("Unable to register host IP [" + service.ip + "] for service [" + _self.soajs.param.init.serviceName + "@" + _self.soajs.param.init.serviceVersion + "]");
 						}
 					});
 				}

--- a/server/maintenance.js
+++ b/server/maintenance.js
@@ -145,7 +145,7 @@ let reloadRegistry = (parsedUrl, core, log, param, serviceIp, cb) => {
 	}, function (err, reg) {
 		let response = maintenanceResponse(parsedUrl, param);
 		if (err) {
-			log.warn("Failed to load registry. reusing from previous load. Reason: " + err.message);
+			log.error("Failed to load registry. reusing from previous load. Reason: " + err.message);
 		} else {
 			response.result = true;
 			response.data = cloneAndFilterRegistry(reg);
@@ -236,7 +236,7 @@ let Maintenance = (core, log, param, serviceIp, regEnvironment, awareness_mw, so
 							infoObj = body;
 						}
 						if (!soajsLib.version.validate(infoObj.version)) {
-							log.warn("Failed to register service for [" + infoObj.name + "@" + infoObj.version + "] version should be of format [1.1]");
+							log.error("Failed to register service for [" + infoObj.name + "@" + infoObj.version + "] version should be of format [1.1]");
 							// res.writeHead(200, {'Content-Type': 'application/json'});
 							return res.end(JSON.stringify(response));
 						}
@@ -287,7 +287,7 @@ let Maintenance = (core, log, param, serviceIp, regEnvironment, awareness_mw, so
 									response.result = true;
 									response.data = data;
 								} else {
-									log.warn("Failed to register service for [" + infoObj.name + "] " + err.message);
+									log.error("Failed to register service for [" + infoObj.name + "] " + err.message);
 								}
 								return res.end(JSON.stringify(response));
 							});

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -10,6 +10,7 @@ describe("Starting Gateway Unit test", () => {
         require("./lib/apiPathParam2apiRegExp.js");
         require("./lib/http.js");
         require("./lib/ip.js");
+        require("./lib/logOnce.js");
         require("./lib/param.js");
         require("./lib/parseURL.js");
 

--- a/test/unit/lib/logOnce.js
+++ b/test/unit/lib/logOnce.js
@@ -1,0 +1,81 @@
+"use strict";
+
+/**
+ * @license
+ * Copyright SOAJS All Rights Reserved.
+ *
+ * Use of this source code is governed by an Apache license that can be
+ * found in the LICENSE file at the root of this repository
+ */
+
+const assert = require('assert');
+const helper = require("../../helper.js");
+
+let logOnceLib = helper.requireModule('./lib/logOnce.js');
+const { logOnce, resetLogOnce } = logOnceLib;
+
+describe("Unit test for: lib - logOnce", () => {
+
+	let emitted = [];
+	let log = {
+		error: (input) => {
+			emitted.push({ "level": "error", "input": input });
+		},
+		warn: (input) => {
+			emitted.push({ "level": "warn", "input": input });
+		}
+	};
+
+	beforeEach(() => {
+		emitted = [];
+		resetLogOnce();
+	});
+
+	it("emits the first time", (done) => {
+		let did = logOnce(log, "error", "k1", "boom");
+		assert.strictEqual(did, true);
+		assert.strictEqual(emitted.length, 1);
+		assert.strictEqual(emitted[0].level, "error");
+		assert.strictEqual(emitted[0].input, "boom");
+		done();
+	});
+
+	it("drops repeats of the same key", (done) => {
+		for (let i = 0; i < 100; i++) {
+			logOnce(log, "error", "k1", "boom");
+		}
+		assert.strictEqual(emitted.length, 1);
+		done();
+	});
+
+	it("keeps distinct keys separate", (done) => {
+		logOnce(log, "error", "k1", "one");
+		logOnce(log, "error", "k2", "two");
+		logOnce(log, "error", "k1", "one again");
+		assert.strictEqual(emitted.length, 2);
+		assert.strictEqual(emitted[0].input, "one");
+		assert.strictEqual(emitted[1].input, "two");
+		done();
+	});
+
+	it("honours the requested level", (done) => {
+		logOnce(log, "warn", "k3", "careful");
+		assert.strictEqual(emitted[0].level, "warn");
+		done();
+	});
+
+	it("does not throw on a missing logger or unknown level", (done) => {
+		assert.strictEqual(logOnce(null, "error", "k4", "x"), false);
+		assert.strictEqual(logOnce(log, "nosuchlevel", "k5", "x"), false);
+		assert.strictEqual(emitted.length, 0);
+		done();
+	});
+
+	it("does not consume the key when it could not emit", (done) => {
+		logOnce(null, "error", "k6", "x");
+		let did = logOnce(log, "error", "k6", "now it works");
+		assert.strictEqual(did, true);
+		assert.strictEqual(emitted.length, 1);
+		done();
+	});
+});


### PR DESCRIPTION
## Why

Production runs the gateway at `level: "error"` (`{src: true, level: "error", gke: true}`). That makes `fatal` and `error` the only levels that exist in production — `warn`, `info` and `debug` are equally invisible. An audit of all 195 log calls found conditions that silently degrade the gateway sitting below that line, and one non-error sitting above it.

## Raised to error

All low frequency — startup, registry reload, or already rate-limited — so no flood risk.

| Location | Was | Condition |
|---|---|---|
| `server/controller.js:77` | warn | host ip not found, gateway starts undiscoverable |
| `server/controller.js:319` | warn | host ip registration failed |
| `server/maintenance.js:148` | warn | registry reload failed, running on stale config |
| `server/maintenance.js:239,290` | warn | service registration failed, service undiscoverable |
| `mw/awareness/custom.js:195` | warn | awareness structure build failed |
| `mw/awareness/custom.js:148` | warn | service host failing health check |
| `mw/awarenessEnv/custom.js:29,110` | warn | controller host load / ENV structure build failed |
| `mw/mt/index.js:333` | debug | interConnect peer dropped from the address book |
| `mw/gotoService/redirectToService.js:84` | debug | monitor buffer flush failed |

Two worth calling out:

**interConnect peer drop.** On `getHost` failure the peer is omitted from the injected `awareness.interConnect` list, so the calling service behaves as if it was never configured. Note the asymmetry with the branch above it — a `getLatestVersion` failure still pushes the item. Message now says the peer was dropped.

**Monitor buffer flush.** The buffer is cleared before the request is issued and the HTTP path does not re-queue, so a failed flush loses up to 1000 records. Now reports the count.

## Raised to error, reported once

`mw/cache/index.js:105,122`, `mw/idempotency/index.js:122`, `mw/traffic/index.js:178` — unknown cache/idempotency/throttling model, and unknown cache scope.

These report static misconfiguration discovered inside the request path. The condition cannot resolve itself without a registry change, so reporting per request would flood the only channel production shows. New `lib/logOnce.js` emits the first occurrence per distinct key and drops the rest. Messages now state the consequence explicitly ("Caching is off", "Throttling is off") since a silently disabled feature was the actual failure mode.

## Lowered

`mw/gotoService/index.js:53` — the `/proxy/redirect` deprecation notice fired at **error** on every legacy proxy request. Not an error, and the loudest false signal in the error log. Now `info`.

## Distribution

| Level | Before | After |
|---|---|---|
| error | 79 | 89 |
| debug | 61 | 59 |
| info | 27 | 28 |
| warn | 23 | 10 |
| fatal | 5 | 5 |

The 10 remaining `warn` calls are all appropriate: the three guarded header dumps (debug aids), a precursor to a terminal error already logged at error, and two normal-shutdown/detail lines.

## Testing

`grunt` lint clean, 70 files. `grunt test` 203 passing, up from 197.

Six new cases for `logOnce`: emits first, drops repeats, keeps distinct keys separate, honours the level, survives a missing logger or unknown level, and does not consume the key when it could not emit.

## Deliberately unchanged

- `mw/traffic/model/memory.js:116` throttle rejection stays at error — a real outcome worth seeing, though it will be loud under a burst
- `mw/gotoService/redirectToService.js:169,194` monitor per-request send failures stay at debug — they would flood if soamonitor goes down
- `mw/mt/index.js:327` interConnect `latestVersion` failure stays at debug — the item is still pushed, the call still works
- the 16 `server/controller.js` startup info lines — invisible in production but they are what you read when a pod will not boot