### PR TITLE
Fix misleading index logs and collapse duplicate error lines

### DIFF
--- a/mw/cache/model/mongo.js
+++ b/mw/cache/model/mongo.js
@@ -22,10 +22,18 @@ let model = {
 		if (!model.mongo) {
 			model.mongo = new Mongo(dbConfiguration);
 			model.mongo.createIndex(cache_store, { 'l1': 1, 'l2': 1 }, { unique: true }, (err, index) => {
-				log.debug("Cache index: " + index + " created with error: " + err);
+				if (err) {
+					log.error("Cache index creation failed: " + err.message);
+				} else {
+					log.debug("Cache index created: " + index);
+				}
 			});
 			model.mongo.createIndex(cache_store, { 'expiresAt': 1 }, { expireAfterSeconds: 0 }, (err, index) => {
-				log.debug("Cache TTL index: " + index + " created with error: " + err);
+				if (err) {
+					log.error("Cache TTL index creation failed: " + err.message);
+				} else {
+					log.debug("Cache TTL index created: " + index);
+				}
 			});
 		}
 	},

--- a/mw/idempotency/model/mongo.js
+++ b/mw/idempotency/model/mongo.js
@@ -22,10 +22,18 @@ let model = {
 		if (!model.mongo) {
 			model.mongo = new Mongo(dbConfiguration);
 			model.mongo.createIndex(idempotency_store, { 'l1': 1, 'l2': 1 }, { unique: true }, (err, index) => {
-				log.debug("Idempotency index: " + index + " created with error: " + err);
+				if (err) {
+					log.error("Idempotency index creation failed: " + err.message);
+				} else {
+					log.debug("Idempotency index created: " + index);
+				}
 			});
 			model.mongo.createIndex(idempotency_store, { 'expiresAt': 1 }, { expireAfterSeconds: 0 }, (err, index) => {
-				log.debug("Idempotency TTL index: " + index + " created with error: " + err);
+				if (err) {
+					log.error("Idempotency TTL index creation failed: " + err.message);
+				} else {
+					log.debug("Idempotency TTL index created: " + index);
+				}
 			});
 		}
 	},

--- a/mw/mt/utils.js
+++ b/mw/mt/utils.js
@@ -190,8 +190,7 @@ let utils = {
 						let block = getCachedNetmask(addr);
 						return block && block.contains(ip);
 					} catch (err) {
-						obj.req.soajs.log.error('IP whitelist security configuration failed: ', addr);
-						obj.req.soajs.log.error(err);
+						obj.req.soajs.log.error('IP whitelist security configuration failed for [' + addr + ']: ' + (err.message || err));
 					}
 					return false;
 				}));
@@ -320,8 +319,7 @@ let utils = {
 					let block = getCachedNetmask(addr);
 					return block && block.contains(ip);
 				} catch (err) {
-					obj.req.soajs.log.error('Geographic security configuration failed: ', addr);
-					obj.req.soajs.log.error(err.message);
+					obj.req.soajs.log.error('Geographic security configuration failed for [' + addr + ']: ' + (err.message || err));
 				}
 				return false;
 			}));

--- a/mw/traffic/model/mongo.js
+++ b/mw/traffic/model/mongo.js
@@ -23,7 +23,11 @@ let model = {
         if (!model.mongo) {
             model.mongo = new Mongo(dbConfiguration);
             model.mongo.createIndex(throttling_monitor, { 'l1': 1, 'l2': 1 }, {}, (err, index) => {
-                log.debug("Index: " + index + " created with error: " + err);
+                if (err) {
+                    log.error("Throttling index creation failed: " + err.message);
+                } else {
+                    log.debug("Throttling index created: " + index);
+                }
             });
         }
     },

--- a/test/unit/utilities/utils.js
+++ b/test/unit/utilities/utils.js
@@ -109,6 +109,43 @@ describe("Testing utilities", () => {
 		});
 	});
 
+	it("logErrors - no longer duplicates what the error context reports", (done) => {
+		// the full chain: logErrors -> controllerClientErrorHandler -> controllerErrorHandler
+		let r = makeReq(true);
+		let oauthErr = new Error("The access token provided is invalid.");
+		oauthErr.name = "OAuth2Error";
+		oauthErr.code = 401;
+
+		utils.logErrors(oauthErr, r, res, (e1) => {
+			utils.controllerClientErrorHandler(e1, r, res, (e2) => {
+				utils.controllerErrorHandler(e2, r, res, null);
+			});
+		});
+
+		assert.strictEqual(logged.error.length, 1, "expected exactly one error line for one failure");
+		let ctx = JSON.parse(logged.error[0]);
+		assert.strictEqual(ctx.code, 401);
+		assert.strictEqual(ctx.msg, "The access token provided is invalid.");
+		done();
+	});
+
+	it("logErrors - keeps the underlying cause when it becomes a generic 164", (done) => {
+		// an error with neither code nor msg is replaced by 164, so the context line
+		// cannot report the original. logErrors must still record it.
+		let r = makeReq(true);
+		utils.logErrors({ "message": "socket hang up" }, r, res, (e1) => {
+			utils.controllerClientErrorHandler(e1, r, res, (e2) => {
+				utils.controllerErrorHandler(e2, r, res, null);
+			});
+		});
+
+		assert.strictEqual(logged.error.length, 2);
+		assert.strictEqual(logged.error[0], "socket hang up", "underlying cause must survive");
+		let ctx = JSON.parse(logged.error[1]);
+		assert.strictEqual(ctx.code, 164);
+		done();
+	});
+
 	it("logErrors - string error", (done) => {
 		utils.logErrors("error", req, res, (error) => {
 			done();

--- a/utilities/utils.js
+++ b/utilities/utils.js
@@ -86,13 +86,15 @@ function errorContext(err, req) {
  * @param next
  */
 function logErrors(err, req, res, next) {
+    //NOTE: every error routed here reaches controllerErrorHandler, which logs a
+    //      structured context carrying the code and the message. The cases below
+    //      only log what that context cannot reproduce, which is the underlying
+    //      cause of an error that gets replaced by the generic 164.
     if (typeof err === "number") {
-        req.soajs.log.error(core.error.generate(err).message);
         return next(err);
     }
     if (typeof err === "object") {
         if (err.code && err.message) {
-            req.soajs.log.error(err.message);
             if (err.name === "OAuth2Error") {
                 return next({ "code": err.code, "status": err.code, "msg": err.message });
             } else {
@@ -100,15 +102,12 @@ function logErrors(err, req, res, next) {
             }
         } else if (err.code && err.msg) {
             err.message = err.msg;
-            req.soajs.log.error(err.message);
             return next(err);
         } else {
             req.soajs.log.error(err.message || err);
-            req.soajs.log.error(core.error.generate(164).message);
         }
     } else {
         req.soajs.log.error(err);
-        req.soajs.log.error(core.error.generate(164).message);
     }
 
     return next(core.error.getError(164));


### PR DESCRIPTION
Cleanup half of the logging audit. Companion to #35, which handles the level corrections. No file overlap between the two, so they merge independently.

## Index creation logged unconditionally

```js
model.mongo.createIndex(cache_store, {...}, (err, index) => {
    log.debug("Cache index: " + index + " created with error: " + err);
});
```

On success this prints `created with error: null`. On a genuine failure it lands at `debug`, which production never sees. Both halves wrong.

Now only failures are logged, at `error`, and the success line says what it means. Five call sites: `mw/cache/model/mongo.js:25,28`, `mw/idempotency/model/mongo.js:25,28`, `mw/traffic/model/mongo.js:26`.

## Duplicate error lines

`mw/mt/utils.js:193-194` and `:323-324` emitted the address and the error as two separate records for one event. Collapsed into one line each, now including the address in the message rather than as a second argument.

## logErrors duplicated the error context

Since #34, `controllerErrorHandler` emits a structured context containing `code` and `msg` for every error response. `logErrors` was still logging the message separately, so one failed request produced two overlapping error lines.

Dropped the three cases the context reproduces exactly (numeric code, `{code, message}`, `{code, msg}`). Kept the two branches where the error is replaced by a generic 164 — there the context can only report 164, so `logErrors` is the sole record of the underlying cause.

The `xhr` branch of `controllerClientErrorHandler` is the one path that could otherwise lose detail, since it swaps the original error for 150. It is unreachable in this stack: `req.xhr` is an express property and the gateway runs on `connect` over a raw http server, so nothing populates it. Verified by grep — the property is read at `utilities/utils.js:127` and never assigned anywhere outside the tests.

## Not changed — correcting my own audit

I had flagged three pairs in `mw/awareness/ha.js` (`85/87`, `144/146`, `288/290`) as duplicate logging. They are not:

```js
if (error.message) {
    param.log.error(error.message);
} else {
    param.log.error(error);
}
```

Either/or, only one fires. Left alone.

## Testing

`grunt` lint clean. `grunt test` 199 passing, up from 197.

Two new cases:
- **one error line per failure** — drives the full `logErrors` → `controllerClientErrorHandler` → `controllerErrorHandler` chain with an OAuth2Error and asserts exactly one record, with `code` 401 and the original message intact
- **underlying cause survives** — an error with neither code nor msg becomes a 164; asserts two records, the first being `"socket hang up"` and the second the 164 context