### PR TITLE
Stop double logging errors that the error context already reports

### DIFF
--- a/mw/keyACL/index.js
+++ b/mw/keyACL/index.js
@@ -48,7 +48,7 @@ module.exports = () => {
 					if (obj.service_v) {
 						let san_v = coreLibs.version.sanitize(obj.service_v);
 						if (!aclObj[san_v]) {
-							obj.req.soajs.log.error("Problem accessing service [" + obj.req.soajs.controller.serviceParams.service_n + "] & version [" + obj.req.soajs.controller.serviceParams.service_v + "]");
+							//NOTE: the error context already reports the service and the version
 							return cb(154, null);
 						}
 						aclObj = aclObj[san_v];

--- a/mw/mt/index.js
+++ b/mw/mt/index.js
@@ -48,7 +48,7 @@ module.exports = (configuration) => {
 				serviceInfo = req.soajs.controller.serviceParams.registry.versions[req.soajs.controller.serviceParams.version];
 			}
 			if (!serviceInfo) {
-				req.soajs.log.error("Problem accessing service [" + req.soajs.controller.serviceParams.name + "], API [" + req.soajs.controller.serviceParams.path + "] & version [" + req.soajs.controller.serviceParams.version + "]");
+				//NOTE: the error context already reports the service, the api and the version
 				return next(133);
 			}
 			let oauth = true;
@@ -160,11 +160,15 @@ module.exports = (configuration) => {
 								//if this is controller route: /key/permission/get, ignore async waterfall response
 								if (url_keyACL) {
 									if (!req.soajs.uracDriver) {
+										if (err && err.name === "OAuth2Error") {
+											//NOTE: the code and the message travel with the error, the
+											//		error context reports both with full attribution
+											return next(err);
+										}
+										//NOTE: the cause is replaced by 158 below, so it is only
+										//		recoverable from here
 										if (err && err.message) {
 											req.soajs.log.error(err.message);
-										}
-										if (err && err.name === "OAuth2Error") {
-											return next(err);
 										}
 										//doesn't work if you are not logged in
 										return next(158);
@@ -180,7 +184,8 @@ module.exports = (configuration) => {
 								}
 
 								if (err) {
-									req.soajs.log.error("Problem accessing service [" + req.soajs.controller.serviceParams.name + "], API [" + req.soajs.controller.serviceParams.path + "] & version [" + req.soajs.controller.serviceParams.version + "]");
+									//NOTE: the error context already reports the service, the api and
+									//		the version alongside the code and the message
 									return next(err);
 								} else {
 									let serviceName = data.req.soajs.controller.serviceParams.name;

--- a/test/unit/utilities/utils.js
+++ b/test/unit/utilities/utils.js
@@ -146,6 +146,19 @@ describe("Testing utilities", () => {
 		done();
 	});
 
+	it("errorContext - falls back to service_n and service_v before gotoService resolves them", (done) => {
+		// key and keyACL run before gotoService, so serviceParams carries only the
+		// raw service_n / service_v at that point
+		let r = makeReq(true);
+		r.soajs.controller.serviceParams = { "service_n": "urac", "service_v": "3" };
+		utils.controllerErrorHandler(154, r, res, null);
+
+		let ctx = JSON.parse(logged.error[0]);
+		assert.strictEqual(ctx.service, "urac");
+		assert.strictEqual(ctx.version, "3");
+		done();
+	});
+
 	it("logErrors - string error", (done) => {
 		utils.logErrors("error", req, res, (error) => {
 			done();

--- a/utilities/utils.js
+++ b/utilities/utils.js
@@ -51,8 +51,10 @@ function errorContext(err, req) {
         "code": code,
         "msg": msg,
         "method": req.method,
+        //NOTE: name and version are resolved by gotoService, the service_n and service_v
+        //		fallbacks cover the middleware that runs before it, ex: key and keyACL
         "service": serviceParams.name || serviceParams.service_n || null,
-        "version": serviceParams.version || null,
+        "version": serviceParams.version || serviceParams.service_v || null,
         "api": (serviceParams.parsedUrl && serviceParams.parsedUrl.pathname) || null,
         "url": redactUrl(req.url),
         "ip": req.getClientIP ? req.getClientIP() : null,


### PR DESCRIPTION
Reported from production: an invalid access token on `/soajs/acl` produced two ERROR records for one failure.

```
{"code":401,"msg":"The access token provided is invalid.","method":"GET","service":"controller", ...}
The access token provided is invalid.
```

The GKE payload pinned the second one to `src: {file: mw/mt/index.js, line: 164}` — a different source than the `logErrors` duplication fixed in #36.

## The cause

```js
if (url_keyACL) {
    if (!req.soajs.uracDriver) {
        if (err && err.message) {
            req.soajs.log.error(err.message);      // <-- bare, no attribution
        }
        if (err && err.name === "OAuth2Error") {
            return next(err);                       // <-- code + message reach the context
        }
        return next(158);                           // <-- code + message replaced
    }
```

The statement guards two exits. On the `next(err)` path the context reports the same message with full attribution, so the bare line is pure noise. On the `next(158)` path the cause is replaced and the log is the only record of it.

Reordered so `OAuth2Error` returns first, leaving the log on the path that actually needs it.

## Also removed

Three that the context reproduces in full, all routed via `next()`:

| Location | Message | Why redundant |
|---|---|---|
| `mw/mt/index.js:51` | `Problem accessing service [x], API [y] & version [z]` → `next(133)` | service / api / version are structured fields on the context |
| `mw/mt/index.js:183` | same → `next(err)` | same, plus the error's own code and message |
| `mw/keyACL/index.js:51` | `Problem accessing service [x] & version [y]` → `cb(154)` → `next(154)` | same |

`keyACL` and `key` run **before** `gotoService` resolves `serviceParams.name` and `.version`, so `errorContext` now falls back to `service_n` / `service_v`. Without that the version would have been silently lost by the third removal.

## Kept

- `mw/mt/utils.js:630` — precedes `cb(146)`, which replaces the code, so it is the only record of the cause
- the two `logErrors` branches ending in a generic 164 — same reason
- `mw/mt/utils.js:677,704` — these reach the context intact, but the surrounding `cb` can transform the code depending on caller, so left alone rather than removed on a guess

## Worth noting

`req.soajs.controllerResponse` writes via `res.end()` and never calls `next()`, so errors sent that way — `preRedirect` 133/134, `redirectToService` 135, `gotoService` 130/132, `url` 130/136, ip2ban, maintenanceMode, traffic 429, idempotency 409/428 — bypass the error chain entirely. They never had a duplicate, and they also get no context line. That is a coverage gap, not a duplication one, and it overlaps the pre-dispatch monitor blind spot already on the follow-up list.

## Testing

`grunt` lint clean, 70 files. `grunt test` 206 passing, up from 205.

New case asserts the `service_n` / `service_v` fallback.

End-to-end reproduction of the reported flow through the real `utils`, driving the reordered branch into `logErrors` → `controllerClientErrorHandler` → `controllerErrorHandler`:

- invalid access token → **1** record, matching the reported production line field for field
- non-oauth error → **2** records, the cause followed by the 158 context, which is correct since 158 cannot carry it